### PR TITLE
Fix pattern matching wrongly using  which is empty

### DIFF
--- a/src/Icon/IconTables.php
+++ b/src/Icon/IconTables.php
@@ -59,7 +59,7 @@ class IconTables
       protected function test($pattern, $subject)
       {
         if(($p = substr($pattern, strlen($pattern) - 2)) === '/g'){
-          return @preg_match_all("$p/", $subject);
+          return @preg_match_all($pattern, $subject);
         }
         return @preg_match($pattern, $subject);
       }


### PR DESCRIPTION
When matching a pdf filename (eg. `Second Semester 2018-2019 Class Survey Results for RESM 520 Academic Writing.pdf`), `mira-icon` is used instead of `icon-file-pdf`. That's because mira has a `/g` here:
https://github.com/websemantics/file-icons/blob/3e533bd01c88f24a21b35d508540a238f286be3d/src/Icon/IconTables.php#L61-L63 and `$p` is an empty string so it matches.